### PR TITLE
fix(linux): Tools.h must be case sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## v0.9 [2021-0x-xx]
+
+### Features
+
+### Fixes
+
+1. [#2](https://github.com/bonitoo-io/weather-station/pull/2): **linux**: Tools.h must be case sensitive
+
+### Other
+
+

--- a/arduino/WeatherStation/ScreenAstronomy.cpp
+++ b/arduino/WeatherStation/ScreenAstronomy.cpp
@@ -1,7 +1,7 @@
 #include <OLEDDisplayUi.h>
 #include <SunMoonCalc.h>
 
-#include "tools.h"
+#include "Tools.h"
 #include "WeatherStationFonts.h"
 
 extern tCurrentWeather currentWeather;

--- a/arduino/WeatherStation/ScreenClock.cpp
+++ b/arduino/WeatherStation/ScreenClock.cpp
@@ -1,5 +1,5 @@
 #include <OLEDDisplayUi.h>
-#include "tools.h"
+#include "Tools.h"
 #include "WeatherStationFonts.h"
 #include "WeatherStationImages.h"
 

--- a/arduino/WeatherStation/ScreenCommon.cpp
+++ b/arduino/WeatherStation/ScreenCommon.cpp
@@ -2,7 +2,7 @@
 #include <ESPWiFi.h>
 #include "WeatherStationFonts.h"
 #include "WeatherStationImages.h"
-#include "tools.h"
+#include "Tools.h"
 
 float getDHTTemp(bool metric);
 float getCurrentWeatherTemperature();

--- a/arduino/WeatherStation/ScreenDHTSensor.cpp
+++ b/arduino/WeatherStation/ScreenDHTSensor.cpp
@@ -1,6 +1,6 @@
 #include <OLEDDisplayUi.h>
 #include <DHT.h>
-#include "tools.h"
+#include "Tools.h"
 #include "WeatherStationFonts.h"
 #include "WeatherStationImages.h"
 

--- a/arduino/WeatherStation/ScreenWeather.cpp
+++ b/arduino/WeatherStation/ScreenWeather.cpp
@@ -2,7 +2,7 @@
 #include <OpenWeatherMapCurrent.h>
 #include <OpenWeatherMapForecast.h>
 
-#include "tools.h"
+#include "Tools.h"
 #include "WeatherStationFonts.h"
 #include "WeatherStationImages.h"
 

--- a/arduino/WeatherStation/Tools.cpp
+++ b/arduino/WeatherStation/Tools.cpp
@@ -1,4 +1,4 @@
-#include "tools.h"
+#include "Tools.h"
 
 // Adjust according to your language
 const char* const WDAY_NAMES[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};

--- a/arduino/WeatherStation/WeatherStation.ino
+++ b/arduino/WeatherStation/WeatherStation.ino
@@ -7,7 +7,7 @@
 #include <SSD1306Wire.h>
 #include <OLEDDisplayUi.h>
 
-#include "tools.h"
+#include "Tools.h"
 
 /***************************
  * Begin Settings
@@ -37,7 +37,7 @@
 #define BUTTONHPIN D3   //Boot button pin
 #define LED        D2   //LED pin
 
-#include "custom_dev.h" //Custom development configuration - remove or comment it out 
+//#include "custom_dev.h" //Custom development configuration - remove or comment it out 
 
 tConfig conf = {
   WIFI_SSID,  //wifi_ssid


### PR DESCRIPTION
Closes #1 

To fix compilation errors, the tools.h reference was in lower-case..

Changed the reference to Camelcase.
