### PR TITLE
fix: releasing memory before upgrade

### DIFF
--- a/arduino/WeatherStation/InfluxDBHelper.h
+++ b/arduino/WeatherStation/InfluxDBHelper.h
@@ -38,7 +38,8 @@ class InfluxDBHelper {
   void update( bool firstStart, const String &deviceID,  const String &wifi, const String &version, const String &location, bool metric);
   void write( float temp, float hum, const float lat, const float lon);
   void loadTempHistory(const String &deviceID, bool metric);
-  static String validateConnection(const String &serverUrl, const String &org, const String &bucket, const String &authToken);
+  void release();
+  String validateConnection(const String &serverUrl, const String &org, const String &bucket, const String &authToken);
 private:
   InfluxDBSettings *_settings = nullptr;
   InfluxDBClient *_client = nullptr;
@@ -57,7 +58,7 @@ enum class ValidationStatus {
 
 class InfluxDBValidateParamsEndpoint {
 public:
-    InfluxDBValidateParamsEndpoint(AsyncWebServer* server);
+    InfluxDBValidateParamsEndpoint(AsyncWebServer* server, InfluxDBHelper *helper);
     virtual ~InfluxDBValidateParamsEndpoint() { delete _validationSettings; }
     void loop();
 private:
@@ -65,6 +66,7 @@ private:
     void checkStatus(AsyncWebServerRequest* request);
 private:
     InfluxDBSettings *_validationSettings;
+    InfluxDBHelper *_helper;
     ValidationStatus _status;
     String _error;
     AsyncCallbackJsonWebHandler _validateHandler;

--- a/arduino/WeatherStation/Updater.cpp
+++ b/arduino/WeatherStation/Updater.cpp
@@ -13,7 +13,7 @@ void Updater::init(UpdaterSettings *settings, const char *currentVersion) {
 }
 
 
-void Updater::checkUpdate() {
+bool Updater::checkUpdate() {
   WS_DEBUG_RAM("Before GH update");
   ESPGithubUpdater ghUpdater(_settings->owner, _settings->repo, _settings->binFile);
   ghUpdater.setMD5FileName(_settings->md5File);
@@ -50,6 +50,7 @@ void Updater::checkUpdate() {
     Serial.println(ghUpdater.getLastError());
   }
   WS_DEBUG_RAM("After GH update");
+  return res;
 }
 
 void printUpdaterSettings(String prefix, UpdaterSettings *s) {

--- a/arduino/WeatherStation/Updater.h
+++ b/arduino/WeatherStation/Updater.h
@@ -15,6 +15,7 @@ typedef std::function<void(bool success, const char *error)> FWUpdateFinishedCal
 #define UPDATER_DEFAULT_MD5_FILE F("ws-firmware-%version%.md5")
 #define UPDATER_DEFAULT_UPDATETIME 300 //HHMM
 #define UPDATER_DEFAULT_CHECKBETA  true
+#define UPDATER_SETTINGS_ENDPOINT_PATH "/api/updaterSettings"
 
 class UpdaterSettings : public Settings {
  public:
@@ -35,7 +36,7 @@ class Updater {
  public:
   Updater();
   void init(UpdaterSettings *settings, const char *currentVersion);
-  void checkUpdate();
+  bool checkUpdate();
   void setUpdateCallbacks(FWUpdateStartedCallback startCb, FWUpdateProgressCallback progCb, FWUpdateFinishedCallback endCb) {
     _startCb = startCb;
     _progCb = progCb;

--- a/arduino/WeatherStation/WeatherStation.cpp
+++ b/arduino/WeatherStation/WeatherStation.cpp
@@ -10,10 +10,11 @@ WeatherStation::WeatherStation(tConfig *conf, InfluxDBHelper *influxDBHelper):
   _wifiScanner(&_server),
   _wifiSettingsEndpoint(&_server, WIFI_SETTINGS_ENDPOINT_PATH, &_persistence, &_wifiSettings),
   _influxDBSettingsEndpoint(&_server, INFLUXDB_SETTINGS_ENDPOINT_PATH, &_persistence, &_influxDBSettings),
+  _updaterSettingsEndpoint(&_server, UPDATER_SETTINGS_ENDPOINT_PATH, &_persistence, &_updaterSettings),
   _wifiStatusEndpoint(&_server),
   _aboutInfoEndpoint(&_server, conf, influxDBHelper, &_influxDBSettings, &_wifiSettings, &LittleFS),
   _aboutServiceEndpoint(&_server, &_persistence),
-  _influxdbValidateEndpoint(&_server)
+  _influxdbValidateEndpoint(&_server, influxDBHelper)
   {
 #if 1
   // Serve static resources from PROGMEM

--- a/arduino/WeatherStation/WeatherStation.h
+++ b/arduino/WeatherStation/WeatherStation.h
@@ -46,6 +46,7 @@ private:
     WiFiScannerEndpoint _wifiScanner;
     SettingsEndpoint _wifiSettingsEndpoint;
     SettingsEndpoint _influxDBSettingsEndpoint;
+    SettingsEndpoint _updaterSettingsEndpoint;
     WiFiStatusEndpoint _wifiStatusEndpoint;
     AboutInfoEndpoint _aboutInfoEndpoint;
     AboutServiceEndpoint _aboutServiceEndpoint;


### PR DESCRIPTION
Closes #12 

Releasing influxdb client before memory hungry routines
- iploc
- update
- influxdb setting validation
- added updaterSettings API endpoint